### PR TITLE
Agrega la seccion "Ventas" al panel admin (#19, #24, #25)

### DIFF
--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -1,3 +1,4 @@
+from datetime import date, timedelta
 from io import BytesIO
 
 from flask import (
@@ -41,6 +42,27 @@ def admin_panel():
         for estado in ("pendiente", "preparacion", "enviado", "entregado", "anulado")
     }
 
+    filtro_desde = request.args.get("desde") or ""
+    filtro_hasta = request.args.get("hasta") or ""
+
+    resumen_ventas = orders_service.resumen_ventas_periodo(
+        filtro_desde or None, filtro_hasta or None
+    )
+    ventas_metodo = orders_service.ventas_por_metodo_pago(
+        filtro_desde or None, filtro_hasta or None
+    )
+    ventas_ciudad = orders_service.ventas_por_ciudad(
+        filtro_desde or None, filtro_hasta or None
+    )
+    max_ventas_metodo = max((v["total"] for v in ventas_metodo), default=0)
+    max_ventas_ciudad = max((v["total"] for v in ventas_ciudad), default=0)
+
+    hoy = date.today()
+    preset_hoy = hoy.isoformat()
+    preset_7dias = (hoy - timedelta(days=6)).isoformat()
+    preset_30dias = (hoy - timedelta(days=29)).isoformat()
+    preset_mes = hoy.replace(day=1).isoformat()
+
     return render_template(
         "indexmvc.html",
         users=users,
@@ -61,6 +83,17 @@ def admin_panel():
         error_producto=session.pop("error_producto", None),
         error_pedido=session.pop("error_pedido", None),
         error_categoria=session.pop("error_categoria", None),
+        filtro_desde=filtro_desde,
+        filtro_hasta=filtro_hasta,
+        resumen_ventas=resumen_ventas,
+        ventas_metodo=ventas_metodo,
+        ventas_ciudad=ventas_ciudad,
+        max_ventas_metodo=max_ventas_metodo,
+        max_ventas_ciudad=max_ventas_ciudad,
+        preset_hoy=preset_hoy,
+        preset_7dias=preset_7dias,
+        preset_30dias=preset_30dias,
+        preset_mes=preset_mes,
     )
 
 

--- a/app/services/orders_service.py
+++ b/app/services/orders_service.py
@@ -99,6 +99,98 @@ def listar_pedidos():
     return pedidos
 
 
+def _condicion_periodo(fecha_inicio, fecha_fin, alias):
+    """Arma el WHERE de un reporte de ventas: excluye anulados y, si se
+    dan, acota por fecha (inclusive en ambos extremos).
+
+    Devuelve (sql_where, parametros) para usar con `.format()` + cursor.
+    """
+    condiciones = ["{}.estado != 'anulado'".format(alias)]
+    parametros = []
+
+    if fecha_inicio:
+        condiciones.append("{}.fecha >= %s".format(alias))
+        parametros.append(fecha_inicio + " 00:00:00")
+
+    if fecha_fin:
+        condiciones.append("{}.fecha <= %s".format(alias))
+        parametros.append(fecha_fin + " 23:59:59")
+
+    return " AND ".join(condiciones), parametros
+
+
+def resumen_ventas_periodo(fecha_inicio=None, fecha_fin=None):
+    """Total vendido y cantidad de pedidos (no anulados) en un rango de
+    fechas. Sin fecha_inicio/fecha_fin no hay limite en ese extremo.
+    """
+    where, parametros = _condicion_periodo(fecha_inicio, fecha_fin, "facturas")
+
+    conexion = conectar()
+    cursor = conexion.cursor()
+    cursor.execute(
+        """
+        SELECT COUNT(*) AS cantidad, COALESCE(SUM(total), 0) AS total
+        FROM facturas
+        WHERE {}
+        """.format(where),
+        parametros,
+    )
+    resumen = cursor.fetchone()
+    conexion.close()
+    return resumen
+
+
+def ventas_por_metodo_pago(fecha_inicio=None, fecha_fin=None):
+    """Ventas (no anuladas) agrupadas por metodo de pago, de mayor a menor."""
+    where, parametros = _condicion_periodo(fecha_inicio, fecha_fin, "f")
+
+    conexion = conectar()
+    cursor = conexion.cursor()
+    cursor.execute(
+        """
+        SELECT mp.nombre AS etiqueta,
+               COUNT(*) AS cantidad,
+               COALESCE(SUM(f.total), 0) AS total
+        FROM facturas f
+        JOIN metodos_pago mp ON mp.id = f.metodo_pago_id
+        WHERE {}
+        GROUP BY mp.id, mp.nombre
+        ORDER BY total DESC
+        """.format(where),
+        parametros,
+    )
+    filas = cursor.fetchall()
+    conexion.close()
+    return filas
+
+
+def ventas_por_ciudad(fecha_inicio=None, fecha_fin=None):
+    """Ventas (no anuladas) agrupadas por ciudad/departamento de envio,
+    de mayor a menor.
+    """
+    where, parametros = _condicion_periodo(fecha_inicio, fecha_fin, "f")
+
+    conexion = conectar()
+    cursor = conexion.cursor()
+    cursor.execute(
+        """
+        SELECT COALESCE(NULLIF(d.ciudad, ''), 'Sin ciudad') AS ciudad,
+               d.departamento,
+               COUNT(*) AS cantidad,
+               COALESCE(SUM(f.total), 0) AS total
+        FROM facturas f
+        JOIN direcciones d ON d.id = f.direccion_id
+        WHERE {}
+        GROUP BY d.ciudad, d.departamento
+        ORDER BY total DESC
+        """.format(where),
+        parametros,
+    )
+    filas = cursor.fetchall()
+    conexion.close()
+    return filas
+
+
 def _restaurar_stock(cursor, factura_id):
     """Devuelve a `existencias` lo que se habia descontado de un pedido.
 

--- a/app/static/css/admin.css
+++ b/app/static/css/admin.css
@@ -995,3 +995,147 @@ select {
     color: #fca5a5;
     font-size: 14px;
 }
+
+/* =========================
+   SECCIÓN "VENTAS"
+   ========================= */
+
+.ventas-filtros {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 18px;
+}
+
+.ventas-presets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.ventas-presets a {
+    padding: 8px 16px;
+
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 50px;
+
+    color: white;
+    opacity: 0.65;
+    font-size: 13px;
+
+    transition: 0.25s;
+}
+
+.ventas-presets a:hover {
+    opacity: 1;
+}
+
+.ventas-presets a.active {
+    opacity: 1;
+    background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+.ventas-rango {
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+}
+
+.ventas-rango label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 12px;
+}
+
+.ventas-rango input[type="date"] {
+    padding: 9px 12px;
+
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+
+    background: rgba(255, 255, 255, 0.04);
+    color: white;
+    font-size: 13px;
+}
+
+.ventas-rango .secondary-btn {
+    padding: 9px 18px;
+    border-radius: 8px;
+    font-size: 13px;
+}
+
+/* lista de barras horizontales de una sola serie: la longitud codifica
+   la magnitud, sin necesidad de leyenda (ver skill de dataviz) */
+.bar-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.bar-row {
+    display: grid;
+    grid-template-columns: minmax(120px, 200px) 1fr auto;
+    align-items: center;
+    gap: 16px;
+}
+
+.bar-label {
+    overflow: hidden;
+
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 13px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.bar-track {
+    height: 18px;
+
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 4px;
+
+    overflow: hidden;
+}
+
+.bar-fill {
+    height: 100%;
+    min-width: 3px;
+
+    background: var(--color-accent);
+    border-radius: 0 4px 4px 0;
+
+    transition:
+        width 0.4s ease,
+        filter 0.2s ease;
+}
+
+.bar-row:hover .bar-fill {
+    filter: brightness(1.15);
+}
+
+.bar-value {
+    min-width: 90px;
+
+    color: white;
+    font-size: 13px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+}
+
+@media (max-width: 700px) {
+    .bar-row {
+        grid-template-columns: 1fr;
+        gap: 6px;
+    }
+
+    .bar-value {
+        text-align: left;
+    }
+}

--- a/app/templates/indexmvc.html
+++ b/app/templates/indexmvc.html
@@ -138,6 +138,15 @@
 
                 <button
                     class="admin-nav-btn"
+                    data-section="section-ventas"
+                    onclick="showAdminSection('section-ventas', this)"
+                >
+                    <i class="fa-solid fa-chart-line"></i>
+                    Ventas
+                </button>
+
+                <button
+                    class="admin-nav-btn"
                     data-section="section-mensajes"
                     onclick="showAdminSection('section-mensajes', this)"
                 >
@@ -982,6 +991,153 @@
                         <div class="empty-state">
                             <i class="fa-solid fa-box-open"></i>
                             <p>Aún no hay pedidos registrados.</p>
+                        </div>
+                        {% endif %}
+                    </div>
+                </section>
+
+                <!-- ================= VENTAS ================= -->
+                <section class="admin-section" id="section-ventas">
+                    <div>
+                        <h1 class="admin-page-title">Ventas</h1>
+                        <p class="admin-page-subtitle">
+                            Analiza las ventas totales por periodo, método de pago y ciudad de envío.
+                        </p>
+                    </div>
+
+                    <div class="section-card">
+                        <div class="section-card-header">
+                            <h2>Periodo</h2>
+                        </div>
+
+                        <form
+                            action="{{ url_for('admin.admin_panel') }}#section-ventas"
+                            method="GET"
+                            class="ventas-filtros"
+                        >
+                            <div class="ventas-presets">
+                                <a
+                                    href="{{ url_for('admin.admin_panel', desde=preset_hoy, hasta=preset_hoy) }}#section-ventas"
+                                    class="{{ 'active' if filtro_desde == preset_hoy and filtro_hasta == preset_hoy else '' }}"
+                                >
+                                    Hoy
+                                </a>
+                                <a
+                                    href="{{ url_for('admin.admin_panel', desde=preset_7dias, hasta=preset_hoy) }}#section-ventas"
+                                    class="{{ 'active' if filtro_desde == preset_7dias and filtro_hasta == preset_hoy else '' }}"
+                                >
+                                    Últimos 7 días
+                                </a>
+                                <a
+                                    href="{{ url_for('admin.admin_panel', desde=preset_30dias, hasta=preset_hoy) }}#section-ventas"
+                                    class="{{ 'active' if filtro_desde == preset_30dias and filtro_hasta == preset_hoy else '' }}"
+                                >
+                                    Últimos 30 días
+                                </a>
+                                <a
+                                    href="{{ url_for('admin.admin_panel', desde=preset_mes, hasta=preset_hoy) }}#section-ventas"
+                                    class="{{ 'active' if filtro_desde == preset_mes and filtro_hasta == preset_hoy else '' }}"
+                                >
+                                    Este mes
+                                </a>
+                                <a
+                                    href="{{ url_for('admin.admin_panel') }}#section-ventas"
+                                    class="{{ 'active' if not filtro_desde and not filtro_hasta else '' }}"
+                                >
+                                    Todo el tiempo
+                                </a>
+                            </div>
+
+                            <div class="ventas-rango">
+                                <label>
+                                    Desde
+                                    <input type="date" name="desde" value="{{ filtro_desde }}" />
+                                </label>
+                                <label>
+                                    Hasta
+                                    <input type="date" name="hasta" value="{{ filtro_hasta }}" />
+                                </label>
+                                <button type="submit" class="secondary-btn">Filtrar</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <div class="stats-grid">
+                        <div class="stat-card">
+                            <div class="stat-icon">
+                                <i class="fa-solid fa-sack-dollar"></i>
+                            </div>
+                            <div>
+                                <div class="stat-value">$ {{ "{:,.0f}".format(resumen_ventas.total) }}</div>
+                                <div class="stat-label">Ventas totales en el periodo</div>
+                            </div>
+                        </div>
+
+                        <div class="stat-card">
+                            <div class="stat-icon">
+                                <i class="fa-solid fa-receipt"></i>
+                            </div>
+                            <div>
+                                <div class="stat-value">{{ resumen_ventas.cantidad }}</div>
+                                <div class="stat-label">Pedidos en el periodo</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="section-card">
+                        <div class="section-card-header">
+                            <h2>Ventas por método de pago</h2>
+                        </div>
+
+                        {% if ventas_metodo %}
+                        <div class="bar-list">
+                            {% for v in ventas_metodo %}
+                            <div class="bar-row">
+                                <span class="bar-label" title="{{ v.etiqueta }}">{{ v.etiqueta }}</span>
+                                <div class="bar-track">
+                                    <div
+                                        class="bar-fill"
+                                        style="width: {{ (v.total / max_ventas_metodo * 100) if max_ventas_metodo else 0 }}%"
+                                    ></div>
+                                </div>
+                                <span class="bar-value">$ {{ "{:,.0f}".format(v.total) }}</span>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <div class="empty-state">
+                            <i class="fa-solid fa-chart-simple"></i>
+                            <p>No hay ventas registradas en este periodo.</p>
+                        </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="section-card">
+                        <div class="section-card-header">
+                            <h2>Ventas por ciudad / departamento</h2>
+                        </div>
+
+                        {% if ventas_ciudad %}
+                        <div class="bar-list">
+                            {% for v in ventas_ciudad %}
+                            <div class="bar-row">
+                                <span class="bar-label" title="{{ v.ciudad }}{% if v.departamento %}, {{ v.departamento }}{% endif %}">
+                                    {{ v.ciudad }}{% if v.departamento %}, {{ v.departamento }}{% endif %}
+                                </span>
+                                <div class="bar-track">
+                                    <div
+                                        class="bar-fill"
+                                        style="width: {{ (v.total / max_ventas_ciudad * 100) if max_ventas_ciudad else 0 }}%"
+                                    ></div>
+                                </div>
+                                <span class="bar-value">$ {{ "{:,.0f}".format(v.total) }}</span>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <div class="empty-state">
+                            <i class="fa-solid fa-chart-simple"></i>
+                            <p>No hay ventas registradas en este periodo.</p>
                         </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
Nueva pestaña con filtro de periodo (atajos + rango personalizado) que muestra: total vendido y N de pedidos del periodo, ventas por metodo de pago y ventas por ciudad/departamento de envio, cada una como una lista de barras horizontales ordenada de mayor a menor. Los pedidos anulados no cuentan como venta.